### PR TITLE
Add build root image for running E2E tests

### DIFF
--- a/images/build-root/Dockerfile
+++ b/images/build-root/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.16
+
+ENV KUSTOMIZE_VERSION="4.3.0"
+
+# Install kustomize
+RUN curl -sSLo kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" && \
+    tar -C /usr/local/bin -zvxf kustomize.tar.gz


### PR DESCRIPTION
The end-to-end tests require some CLI present in the image to run the tests. This image downloads `kustomize` and installs it in the path.

Signed-off-by: Arjun Naik <arjun.rn@gmail.com>