### PR TITLE
Disable operator upgrade test

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -939,6 +939,7 @@ func TestGatewayOwnership(t *testing.T) {
 // TestOperatorUpgrade tests an instance of the Contour custom resource while
 // upgrading the operator from release "latest" to the current version/branch.
 func TestOperatorUpgrade(t *testing.T) {
+	t.Skipf("Upgrade to upstream latest does not currently work.")
 	// Get the current image to use for upgrade testing.
 	current, err := getDeploymentImage(ctx, kclient, operatorName, operatorNs, operatorName)
 	if err != nil {


### PR DESCRIPTION
The upgrade test targets the latest image from upstream which does work correctly with the current operator logic. In the future this test should be modified to test upgrades between releases.