### PR TITLE
Kustomize patch for the contour-operator image

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -23,6 +23,7 @@ patchesStrategicMerge:
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
+- operator_image.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
 # crd/kustomization.yaml

--- a/config/default/operator_image.yaml
+++ b/config/default/operator_image.yaml
@@ -1,0 +1,12 @@
+# This patch updates the operator image to use images built for PRs and other testing images.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: contour-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: contour-operator
+        image: docker.io/projectcontour/contour-operator:main

--- a/hack/operator-image-patch.sh
+++ b/hack/operator-image-patch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE=${1:-docker.io/projectcontour/contour-operator:main}
+
+rm -f config/default/operator_image.yaml
+cat << EOF >> config/default/operator_image.yaml
+# This patch updates the operator image to use images built for PRs and other testing images.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: contour-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: contour-operator
+        image: ${IMAGE}
+EOF
+


### PR DESCRIPTION
Added a kustomize patch for the contour-operator image in the manager. This will allow specifying PR images an simplify testing for PR builds.