### PR TITLE
Set the contour image version used by the contour-operator

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -24,3 +24,4 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
+        - "--contour-image=docker.io/projectcontour/contour:v1.15.1"


### PR DESCRIPTION
Currently the contour-operator uses the "latest" image to provision the resources for a Contour resource. However the not every contour image is guaranteed to work with every operator version. This change fixes the contour image version used by the operator. When updating the operator the contour image version will also have to be updated.